### PR TITLE
add search bar

### DIFF
--- a/src/components/queries/queries.component.js
+++ b/src/components/queries/queries.component.js
@@ -11,6 +11,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import Dialog from '@material-ui/core/Dialog';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import IconButton from '@material-ui/core/IconButton';
+import TextField from '@material-ui/core/TextField';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import styles from './queries.styles.scss';
@@ -25,6 +26,10 @@ export default class Queries extends Component {
     unfavoriteQuery: PropTypes.func.isRequired,
   }
 
+  state = {
+    search: '',
+  }
+
   componentDidMount () {
     const { loadQueries, queries } = this.props;
     if (!queries.length) {
@@ -34,7 +39,7 @@ export default class Queries extends Component {
 
   get cards () {
     const { getFeatures } = this.props;
-    return this.queries.map(({ favorite, name, title, datastore, description }) => (
+    return this.queries.map(({ datastore, description, favorite, name, title }) => (
       <Card key={name} className={styles.query}>
         <CardHeader
           action={this.iconButton(name, favorite)}
@@ -66,15 +71,9 @@ export default class Queries extends Component {
   }
 
   get queries () {
-    return this.props.queries.sort((a, b) => {
-      if (a.favorite && !b.favorite) return -1;
-      if (b.favorite && !a.favorite) return 1;
-      const aTitle = a.title.toLowerCase();
-      const bTitle = b.title.toLowerCase();
-      if (aTitle < bTitle) { return -1; }
-      if (aTitle > bTitle) { return 1; }
-      return 0;
-    });
+    return this.props.queries
+      .sort(this.sortQueries)
+      .filter(::this.filterQueries);
   }
 
   iconButton (name, favorite) {
@@ -91,6 +90,28 @@ export default class Queries extends Component {
 
   handleClose () {
     this.props.history.push('/');
+  }
+
+  handleSearch (e) {
+    const search = e.target.value;
+    this.setState({ search });
+  }
+
+  filterQueries ({ name, title }) {
+    const search = this.state.search.toLowerCase();
+    if (name.toLowerCase().includes(search)) return true;
+    if (title.toLowerCase().includes(search)) return true;
+    return false;
+  }
+
+  sortQueries (a, b) {
+    if (a.favorite && !b.favorite) return -1;
+    if (b.favorite && !a.favorite) return 1;
+    const aTitle = a.title.toLowerCase();
+    const bTitle = b.title.toLowerCase();
+    if (aTitle < bTitle) return -1;
+    if (aTitle > bTitle) return 1;
+    return 0;
   }
 
   toggleFavorite (name, favorite) {
@@ -119,6 +140,21 @@ export default class Queries extends Component {
             </Typography>
           </Toolbar>
         </AppBar>
+        <div className={styles.search}>
+          <TextField
+            fullWidth
+            id="search"
+            label="Search"
+            margin="normal"
+            onChange={::this.handleSearch}
+            placeholder="Thai food"
+            value={this.state.search}
+            variant="outlined"
+            InputLabelProps={{
+              shrink: true,
+            }}
+          />
+        </div>
         <div className={styles.queries}>
           { this.cards }
         </div>

--- a/src/components/queries/queries.styles.scss
+++ b/src/components/queries/queries.styles.scss
@@ -1,6 +1,10 @@
 $tablet-width: 900px;
 $mobile-width: 600px;
 
+.search {
+  padding: 16px;
+}
+
 .queries {
   display: grid;
   padding: 16px;

--- a/src/components/queries/queries.test.js
+++ b/src/components/queries/queries.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+import { BrowserRouter } from 'react-router-dom';
 import Queries from './queries.component';
 
 let props;
+let queries;
+
 describe('Component: Queries', () => {
   beforeEach(() => {
     props = {
@@ -13,6 +16,13 @@ describe('Component: Queries', () => {
       queries: [],
       unfavoriteQuery: jest.fn(),
     };
+
+    queries = [
+      { datastore: 'amenities', description: 'random test query', favorite: false, name: 'thai food', title: 'Thai food' },
+      { datastore: 'amenities', description: 'random test query', favorite: true, name: 'donute stores', title: 'Donuts!!!' },
+      { datastore: 'amenities', description: 'random test query', favorite: false, name: 'bars', title: 'Bars' },
+      { datastore: 'amenities', description: 'random test query', favorite: false, name: 'coffee shops', title: 'Coffee shops' }
+    ];
   });
 
   it('renders', () => {
@@ -24,5 +34,22 @@ describe('Component: Queries', () => {
   it('calls loadQueries if the queries array has a length of 0', () => {
     const component = shallow(<Queries {...props} />);
     expect(props.loadQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('sorts queries alphabetically with favorites at the top', () => {
+    const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
+    const cards = component.find('CardHeader');
+    expect(cards.first().text()).toContain('Donuts!!!');
+    expect(cards.at(1).text()).toContain('Bars');
+    expect(cards.at(2).text()).toContain('Coffee shops');
+    expect(cards.at(3).text()).toContain('Thai food');
+  });
+
+  it('filters out queries that don\'t match the search value', () => {
+    const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
+    component.find('input').simulate('change', { target: { value: 'cof' } });
+    const cards = component.find('CardHeader');
+    expect(cards).toHaveLength(1);
+    expect(cards.text()).toContain('Coffee shops');
   });
 });


### PR DESCRIPTION
Closes #13 

## What
Adds a search bar to the `Queries` page.

Currently the search bar can search over `name` and `title`.

## Issues
Haven't tested yet (can't get railgun to run locally)

## Questions
**1. What other values should we search over?**
**2. Do we need to have more intelligent search functionality?**
**3. Do we need to have autocomplete?**