### PR TITLE
add meta charset tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta name="description" content="this is an app for mapping things">
     <meta name="author" content="Spatial Current">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta charset="utf-8">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
## What
Adds the `<meta charset="utf-8">` tag.

## Why
There is a bug where the "-" zoom control shows a weird symbol instead of the appropriate one in production. This will fix it as seen in [this stackexchange post](https://gis.stackexchange.com/questions/299159/openlayers-5-zoom-control-has-but-zoom-out-button-has-%C3%A2%CB%86-any-idea-why).

Closes #15 