### PR TITLE
Bug/empty results error

### DIFF
--- a/__mocks__/api-client.js
+++ b/__mocks__/api-client.js
@@ -1,10 +1,12 @@
-export const mockExecuteServiceResult = { id: 1, name: 'test-service' };
-export async function executeService (result) {
+export const mockExecuteServiceResult = [{ name: 'feature 1' }, { name: 'feature 2' }];
+export async function executeService (params) {
+  if (params.withError) throw new Error('mock error');
+  if (params.noFeatures) return [];
   return mockExecuteServiceResult;
 }
 
 export const mockGetProcessResult = { id: 1 };
-export async function getProcess (result) {
+export async function getProcess (params) {
   return mockGetProcessResult;
 }
 
@@ -14,7 +16,7 @@ export async function getProcesses () {
 }
 
 export const mockGetServiceResult = { id: 1, name: 'test-service', process: 'test-process' };
-export async function getService (result) {
+export async function getService (params) {
   return mockGetServiceResult;
 }
 

--- a/src/actions/get-features/get-features.action.js
+++ b/src/actions/get-features/get-features.action.js
@@ -10,8 +10,12 @@ export default function (params) {
     dispatch(openLoader());
     try {
       const features = await executeService(params);
-      dispatch({ features, type: GET_FEATURES });
-      await dispatch(getQuery(params.service));
+      if (features.length) {
+        dispatch({ features, type: GET_FEATURES });
+        await dispatch(getQuery(params.service));
+      } else {
+        dispatch(openAlert('There were no results found for this query. Please try another query.'));
+      }
     } catch (e) {
       dispatch(openAlert('There was a problem executing this query. We have been notified of the problem and will work to fix it.'));
     }

--- a/src/actions/get-features/get-features.test.js
+++ b/src/actions/get-features/get-features.test.js
@@ -1,10 +1,11 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import {
-  OPEN_LOADER,
-  GET_QUERY,
-  GET_FEATURES,
   CLOSE_LOADER,
+  GET_FEATURES,
+  GET_QUERY,
+  OPEN_ALERT,
+  OPEN_LOADER,
 } from 'action-types';
 import {
   mockExecuteServiceResult,
@@ -14,15 +15,18 @@ import {
 import getFeatures from './get-features.action';
 
 const mockStore = configureMockStore([thunk]);
+let store;
 
 describe('Action: getFeatures', () => {
-  it('creates open loader, get features, get query, and close loader actions', async () => {
-    const store = mockStore({
+  beforeEach(() => {
+    store = mockStore({
       features: null,
       query: null,
       showLoader: null,
     });
+  });
 
+  it('creates open loader, get features, get query, and close loader actions', async () => {
     const params = { service: 'test-service' };
     const expectedActions = [
       { type: OPEN_LOADER },
@@ -33,5 +37,27 @@ describe('Action: getFeatures', () => {
 
     const updatedStore = await store.dispatch(getFeatures(params));
     expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('creates open alert action when features return empty array', async () => {
+    const params = { service: 'test-service', noFeatures: true };
+    const expectedActions = [
+      { type: OPEN_LOADER },
+      { type: OPEN_ALERT, message: 'There were no results found for this query. Please try another query.' },
+      { type: CLOSE_LOADER },
+    ];
+
+    const updatedStore = await store.dispatch(getFeatures(params));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('creates open alert action when recieving an error', async () => {
+    const params = { servie: 'test-service', withError: true };
+
+    const expectedActions = [
+      { type: OPEN_LOADER },
+      { type: OPEN_ALERT, message: 'There was a problem executing this query. We have been notified of the problem and will work to fix it.' },
+      { type: CLOSE_LOADER },
+    ];
   });
 });

--- a/src/components/map/map.component.js
+++ b/src/components/map/map.component.js
@@ -160,7 +160,8 @@ export default class Map extends Component {
     if (layer) map.removeLayer(layer);
     const newLayer = this.layer();
     map.addLayer(newLayer);
-    map.getView().fit(newLayer.getSource().getExtent());
+    const extent = newLayer.getSource().getExtent();
+    if (extent.every(Number.isFinite)) map.getView().fit(extent);
     this.setState({ layer: newLayer }, ::this.addSelect);
   }
 


### PR DESCRIPTION
## First...
- [x] I added full test coverage for the introduced changes
- [ ] I added new node modules *If so, which packages and why?*
- [ ] I made changes to the build process *If so, why?*

## Problem
When coconut received an empty set of features from railgun, it would completely bomb. This is because when the map would try to fit to the layer's extent, it would fail on infinite values

## Solution
1. Add a catch for infinite extent values before fitting to extent
2. Add a catch in `getFeatures` action to make sure features are returned, and show an alert message if no features are returned

## Steps to test
1. Query for chinese food
2. Note the alert message

## Screenshots

### Before

### After
![image](https://user-images.githubusercontent.com/11160004/51806283-37c19780-2246-11e9-881d-5f2a36ac8eda.png)