### PR TITLE
Feature/tile loading spinner

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "react/forbid-prop-types": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-no-bind": "off",
+    "react/no-access-state-in-setstate": "off",
     "react/prefer-stateless-function": "off",
     "react/require-default-props": "off",
     "sort-keys": "error",

--- a/src/components/loader/loader.component.js
+++ b/src/components/loader/loader.component.js
@@ -19,9 +19,9 @@ export default class Loader extends Component {
         <Chip
           avatar={<CircularProgress size={20} />}
           label="Loading tiles"
+          className={styles.chip}
           color="primary"
           onDelete={closeLoader}
-          variant="outlined"
         />
       </div>
     );

--- a/src/components/loader/loader.component.js
+++ b/src/components/loader/loader.component.js
@@ -1,5 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Avatar from '@material-ui/core/Avatar';
+import Chip from '@material-ui/core/Chip';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import CloseIcon from '@material-ui/icons/Close';
+
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -12,38 +17,20 @@ export default class Loader extends Component {
     showLoader: PropTypes.bool.isRequired,
   }
 
-  state = {
-    completed: 0,
-  }
-
-  componentDidMount () {
-    this.timer = setInterval(this.progress, 500);
-  }
-
-  componentWillUnmount () {
-    clearInterval(this.timer);
-  }
-
-  progress = () => {
-    const { completed } = this.state;
-    if (completed === 100) {
-      this.setState({ completed: 0 });
-    } else {
-      const diff = Math.random() * 10;
-      this.setState({ completed: Math.min(completed + diff, 100) });
-    }
-  }
-
   render () {
     const { closeLoader, showLoader } = this.props;
+    if (!showLoader) return null;
 
     return (
-      <Dialog open={showLoader} onClose={closeLoader}>
-        <DialogTitle>Searching ...</DialogTitle>
-        <DialogContent className={styles.content}>
-          <LinearProgress variant="determinate" value={this.state.completed} />
-        </DialogContent>
-      </Dialog>
+      <div className={styles.loader}>
+        <Chip
+          avatar={<CircularProgress size={20} />}
+          label="Loading tiles"
+          color="primary"
+          onDelete={closeLoader}
+          variant="outlined"
+        />
+      </div>
     );
   }
 }

--- a/src/components/loader/loader.component.js
+++ b/src/components/loader/loader.component.js
@@ -1,14 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Avatar from '@material-ui/core/Avatar';
 import Chip from '@material-ui/core/Chip';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import CloseIcon from '@material-ui/icons/Close';
-
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import LinearProgress from '@material-ui/core/LinearProgress';
 import styles from './loader.styles.scss';
 
 export default class Loader extends Component {

--- a/src/components/loader/loader.styles.scss
+++ b/src/components/loader/loader.styles.scss
@@ -9,11 +9,15 @@ $dialog-width: 400px;
   top: 85px;
   z-index: 999;
 
-  > div {
+  > .chip {
     padding-left: 8px;
 
     > div:first-child {
       background-color: transparent;
+    }
+
+    svg {
+      color: white;
     }
   }
 }

--- a/src/components/loader/loader.styles.scss
+++ b/src/components/loader/loader.styles.scss
@@ -1,7 +1,19 @@
 $dialog-width: 400px;
 
-.content {
-  display: flex;
-  justify-content: center;
-  min-width: $dialog-width;
+.loader {
+  left: 0;
+  margin: auto;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 85px;
+  z-index: 999;
+
+  > div {
+    padding-left: 8px;
+
+    > div:first-child {
+      background-color: transparent;
+    }
+  }
 }

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -4,8 +4,14 @@ import Loader from './loader.component';
 
 describe('Component: Loader', () => {
   it('renders', () => {
-    const component = shallow(<Loader showLoader={false} closeLoader={jest.fn()} />);
-    const loader = component.find('.content');
+    const component = shallow(<Loader showLoader={true} closeLoader={jest.fn()} />);
+    const loader = component.find('.loader');
     expect(loader.exists()).toBe(true);
+  });
+
+  it('doesn\'t render if showLoader is false', () => {
+    const component = shallow(<Loader showLoader={false} closeLoader={jest.fn()} />);
+    const loader = component.find('.loader');
+    expect(loader.exists()).toBe(false);
   });
 });

--- a/src/components/map/map.component.js
+++ b/src/components/map/map.component.js
@@ -72,6 +72,13 @@ export default class Map extends Component {
     return this.state.map.getView().getZoom();
   }
 
+  setTimer () { // not sure why but eslint forces me to put this method up here...
+    clearTimeout(timer);
+    return setTimeout(() => {
+      this.setState({ loadCounter: 0 });
+    }, TIMER_LENGTH);
+  }
+
   addSelect () {
     const { map } = this.state;
     const { setFeature } = this.props;
@@ -159,13 +166,6 @@ export default class Map extends Component {
         }),
       }),
     });
-  }
-
-  setTimer () {
-    clearTimeout(timer);
-    return setTimeout(() => {
-      this.setState({ loadCounter: 0 });
-    }, TIMER_LENGTH);
   }
 
   source () {

--- a/src/components/map/map.component.js
+++ b/src/components/map/map.component.js
@@ -14,23 +14,30 @@ import { Circle, Fill, Stroke, Style } from 'ol/style';
 import 'ol/ol.css';
 import styles from './map.styles.scss';
 
-const INITIAL_ZOOM = 2;
+let timer;
+
 const FEATURE_RADIUS = 8;
 const FEATURE_STROKE_WIDTH = 2;
+const INITIAL_ZOOM = 2;
 const SELECTED_FEATURE_RADIUS = 10;
 const SELECTED_FEATURE_STROKE_WIDTH = 3;
+const TIMER_LENGTH = 4000;
+const VISIBLE_ZOOM_LEVEL = 9;
 
 export default class Map extends Component {
   static propTypes = {
     clearFeature: PropTypes.func.isRequired,
+    closeLoader: PropTypes.func.isRequired,
     extent: PropTypes.array,
     feature: PropTypes.object,
+    openLoader: PropTypes.func.isRequired,
     service: PropTypes.string,
     setFeature: PropTypes.func.isRequired,
   }
 
   state = {
     layer: null,
+    loadCounter: 0,
     map: null,
     select: null,
   }
@@ -50,10 +57,19 @@ export default class Map extends Component {
     if (layer && !feature && feature !== prevProps.feature) {
       select.getFeatures().clear();
     }
+
+    if (!this.state.loadCounter) {
+      clearTimeout(timer);
+      this.props.closeLoader();
+    }
   }
 
   componentWillUnmount () {
     this.props.clearFeature();
+  }
+
+  get currentZoomLevel () {
+    return this.state.map.getView().getZoom();
   }
 
   addSelect () {
@@ -91,8 +107,19 @@ export default class Map extends Component {
     });
   }
 
+  decrementLoader () {
+    const loadCounter = Math.max(this.state.loadCounter - 1, 0);
+    this.setState({ loadCounter });
+  }
+
   initialize () {
     this.setState({ map: this.map() });
+  }
+
+  incrementLoader () {
+    this.props.openLoader();
+    this.setState({ loadCounter: this.state.loadCounter + 1 });
+    timer = this.setTimer();
   }
 
   layer () {
@@ -134,6 +161,13 @@ export default class Map extends Component {
     });
   }
 
+  setTimer () {
+    clearTimeout(timer);
+    return setTimeout(() => {
+      this.setState({ loadCounter: 0 });
+    }, TIMER_LENGTH);
+  }
+
   source () {
     const format = new GeoJSON({
       dataProjection: 'EPSG:4326',
@@ -162,9 +196,12 @@ export default class Map extends Component {
 
   tileLoadFunction (tile, url) {
     tile.setLoader(() => {
+      const validZoomLevel = this.currentZoomLevel >= VISIBLE_ZOOM_LEVEL;
+      if (validZoomLevel) this.incrementLoader();
       const xhr = new XMLHttpRequest(); // eslint-disable-line
       xhr.open('GET', url);
       xhr.onload = () => {
+        if (validZoomLevel) this.decrementLoader();
         const json = JSON.parse(xhr.responseText);
         json.features.forEach(feature => {
           const [z, x, y] = tile.tileCoord;

--- a/src/components/map/map.container.js
+++ b/src/components/map/map.container.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
 import clearFeature from 'actions/clear-feature';
+import closeLoader from 'actions/close-loader';
+import openLoader from 'actions/open-loader';
 import setFeature from 'actions/set-feature';
 import Map from './map.component';
 
@@ -11,6 +13,8 @@ const mapState = ({ feature, query }) => ({
 
 const mapDispatch = {
   clearFeature,
+  closeLoader,
+  openLoader,
   setFeature,
 };
 

--- a/src/components/map/map.test.js
+++ b/src/components/map/map.test.js
@@ -8,7 +8,9 @@ describe('Component: Map', () => {
   beforeEach(() => {
     props = {
       clearFeature: jest.fn(),
+      closeLoader: jest.fn(),
       feature: null,
+      openLoader: jest.fn(),
       setFeature: jest.fn(),
     };
   });


### PR DESCRIPTION
## First...
- [ ] I added full test coverage for the introduced changes - 😬 well...
- [ ] I added new node modules *If so, which packages and why?*
- [ ] I made changes to the build process *If so, why?*

## Problem
Its currently really difficult to know when tiles are loading. This leads to a suboptimal user experience.

This can be remedied with a loader component that activates whenever tiles are loading.

## Solution
1. Redesigned the `<Loader />` component to be less intrusive so that it can be present but not block the user.

2. Added a way of displaying the loader while tiles are loading. This involves (1) tracking how many times the tile load function is called, (2) tracking how many times the tile load function resolves, and (3) adding a timer in case we lose a resolution and auto-close the loader.

## Steps to test
1. Select a query (any query really)
2. Zoom down to the effective zoom level (9)
3. Loader should appear near the top of the screen
4. Try closing the loader, it should disappear
