### PR TITLE
Better logic for website attr

### DIFF
--- a/src/components/panel/panel.component.js
+++ b/src/components/panel/panel.component.js
@@ -101,7 +101,7 @@ export default class Panel extends Component {
       if (value.startsWith('http://') || value.startsWith('https://')) {
         return <a title={value} href={value} className={styles.value}>{ value }</a>;
       }
-      if ((key === 'website' || key === 'contact:website') && value.startsWith('www.')) {
+      if ((key === 'website' || key === 'contact:website') && (value.startsWith('www.') || value.endsWith('.com') || value.endsWith('.org') || value.endsWith('.net'))) {
         return <a title={value} href={`http://${value}`} className={styles.value}>{ value }</a>;
       }
       if ((key === 'email' || key === 'contact:email') && value.indexOf('@') > 0) {


### PR DESCRIPTION
## Problem

Values such as `website=aroithaidc.com` do not render as anchor tags.  Adds some basic validation, so if the value ends with `.com` or `.org` also render a link.
