### PR TITLE
Dont reset extent on new queries

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,18 @@
     "react/no-access-state-in-setstate": "off",
     "react/prefer-stateless-function": "off",
     "react/require-default-props": "off",
+    "react/sort-comp": ["error", {                // Team Preference
+      "order": [
+        "static-methods",
+        "/constructor/",
+        "/state/",
+        "instance-variables",
+        "lifecycle",
+        "getters",
+        "everything-else",
+        "render"
+      ]
+    }],
     "sort-keys": "error",
     "space-before-function-paren": ["error", "always"]
   }

--- a/src/action-types.js
+++ b/src/action-types.js
@@ -12,5 +12,6 @@ export const OPEN_LOADER = 'OPEN_LOADER';
 export const OPEN_MENU = 'OPEN_MENU';
 export const OPEN_QUERY_INFO = 'OPEN_QUERY_INFO';
 export const REMOVE_NOTE = 'REMOVE_NOTE';
+export const SET_EXTENT = 'SET_EXTENT';
 export const SET_FEATURE = 'SET_FEATURE';
 export const UNFAVORITE_QUERY = 'UNFAVORITE_QUERY';

--- a/src/actions/set-extent/index.js
+++ b/src/actions/set-extent/index.js
@@ -1,0 +1,3 @@
+import setExtent from './set-extent.action';
+
+export default setExtent;

--- a/src/actions/set-extent/set-extent.action.js
+++ b/src/actions/set-extent/set-extent.action.js
@@ -1,0 +1,8 @@
+import { SET_EXTENT } from 'action-types';
+
+export default function (extent) {
+  return {
+    extent,
+    type: SET_EXTENT,
+  };
+}

--- a/src/actions/set-extent/set-extent.test.js
+++ b/src/actions/set-extent/set-extent.test.js
@@ -1,0 +1,10 @@
+import { SET_EXTENT } from 'action-types';
+import setExtent from './set-extent.action';
+
+describe('Action: setExtent', () => {
+  it('creates a set extent action', () => {
+    const extent = ['extent'];
+    const expectedAction = { type: SET_EXTENT, extent };
+    expect(setExtent(extent)).toEqual(expectedAction);
+  });
+});

--- a/src/components/map/map.container.js
+++ b/src/components/map/map.container.js
@@ -3,12 +3,14 @@ import addNote from 'actions/add-note';
 import clearFeature from 'actions/clear-feature';
 import closeLoader from 'actions/close-loader';
 import openLoader from 'actions/open-loader';
+import setExtent from 'actions/set-extent';
 import setFeature from 'actions/set-feature';
 import Map from './map.component';
 
-const mapState = ({ feature, query }) => ({
-  extent: query && JSON.parse(query.extent),
+const mapState = ({ extent, feature, query }) => ({
+  extent,
   feature,
+  queryExtent: query && JSON.parse(query.extent),
   service: query ? query.name : '',
 });
 
@@ -17,6 +19,7 @@ const mapDispatch = {
   clearFeature,
   closeLoader,
   openLoader,
+  setExtent,
   setFeature,
 };
 

--- a/src/components/map/map.test.js
+++ b/src/components/map/map.test.js
@@ -8,10 +8,12 @@ describe('Component: Map', () => {
   beforeEach(() => {
     props = {
       addNote: jest.fn(),
+      extent: ['extent'],
       clearFeature: jest.fn(),
       closeLoader: jest.fn(),
       feature: null,
       openLoader: jest.fn(),
+      setExtent: jest.fn(),
       setFeature: jest.fn(),
     };
   });

--- a/src/reducers/extent/extent.reducer.js
+++ b/src/reducers/extent/extent.reducer.js
@@ -1,0 +1,10 @@
+import { SET_EXTENT } from 'action-types';
+
+export default function (state = null, { extent, type }) {
+  switch (type) {
+    case SET_EXTENT:
+      return extent;
+    default:
+      return state;
+  }
+}

--- a/src/reducers/extent/extent.test.js
+++ b/src/reducers/extent/extent.test.js
@@ -1,0 +1,11 @@
+import { SET_EXTENT } from 'action-types';
+import extentReducer from './extent.reducer';
+
+describe('Reducer: extent', () => {
+  it('sets a extent', () => {
+    const action = { extent: 'extent', type: SET_EXTENT };
+    const expectedState = 'extent';
+    const state = extentReducer(null, action);
+    expect(state).toEqual(expectedState);
+  });
+});

--- a/src/reducers/extent/index.js
+++ b/src/reducers/extent/index.js
@@ -1,0 +1,3 @@
+import extent from './extent.reducer';
+
+export default extent;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import alert from './alert';
+import extent from './extent';
 import feature from './feature';
 import notes from './notes';
 import queries from './queries';
@@ -10,6 +11,7 @@ import showQueryInfo from './show-query-info';
 
 export default combineReducers({
   alert,
+  extent,
   feature,
   notes,
   queries,


### PR DESCRIPTION
## First...
- [x] I added full test coverage for the introduced changes
- [ ] I added new node modules *If so, which packages and why?*
- [ ] I made changes to the build process *If so, why?*

## Problem
Closes #39 

When you go from one query to another the map resets to the full extent. We want the extent to reset to the most recent extent from the previous query.

## Solution
1. Create an extent reducer and associated set extent action
2. When the map component loads, check to see if extent is in the redux store
  - If it is, use that extent
  - If it is not, pull the extent from the query result and set that to the new extent
3. Make sure to track any changes to the extent

## Steps to test
1. Load a query
2. Move the map
3. Load a different query
