### PR TITLE
cache queries for quick initial load

### DIFF
--- a/src/actions/load-queries/load-queries.action.js
+++ b/src/actions/load-queries/load-queries.action.js
@@ -1,10 +1,18 @@
 import { LOAD_QUERIES } from 'action-types';
+import storage from 'utils/storage';
 import { getServices } from 'api-client';
 
 export default function () {
   return async dispatch => {
+    // first preload cached queries if they exist
+    const cachedQueries = storage.get('queries', []);
+    dispatch({ queries: cachedQueries, type: LOAD_QUERIES });
+
     const services = await getServices();
     const queries = services.filter(service => service.tags && service.tags.includes('geojson'));
+
+    // cache newly loaded queries
+    storage.set('queries', queries);
     return dispatch({ queries, type: LOAD_QUERIES });
   };
 }

--- a/src/actions/load-queries/load-queries.test.js
+++ b/src/actions/load-queries/load-queries.test.js
@@ -7,13 +7,28 @@ import loadQueries from './load-queries.action';
 const mockStore = configureMockStore([thunk]);
 
 describe('Action: loadQueries', () => {
-  it('creates a get query action', async () => {
-    const store = mockStore({ queries: [] });
-    const updatedStore = await store.dispatch(loadQueries());
-    const expectedAction = {
-      queries: mockGetServicesResult,
-      type: LOAD_QUERIES,
-    };
-    expect(store.getActions()).toEqual([expectedAction]);
+  let store;
+  beforeEach(() => {
+    store = mockStore({ queries: [] });
+  });
+
+  describe('without cached queries', () => {
+    it('creates a get query action with empty results first (no cache)', async () => {
+      await store.dispatch(loadQueries());
+      const expectedAction = {
+        queries: [],
+        type: LOAD_QUERIES,
+      };
+      expect(store.getActions()[0]).toEqual(expectedAction);
+    });
+
+    it('creates a get query action with queries from the server second', async () => {
+      await store.dispatch(loadQueries());
+      const expectedAction = {
+        queries: mockGetServicesResult,
+        type: LOAD_QUERIES,
+      };
+      expect(store.getActions()[1]).toEqual(expectedAction);
+    });
   });
 });

--- a/src/components/queries/queries.component.js
+++ b/src/components/queries/queries.component.js
@@ -4,9 +4,10 @@ import { Link } from 'react-router-dom';
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import CloseIcon from '@material-ui/icons/Close';
 import Dialog from '@material-ui/core/Dialog';
 import FavoriteIcon from '@material-ui/icons/Favorite';
@@ -62,6 +63,11 @@ export default class Queries extends Component {
         </CardActions>
       </Card>
     ));
+  }
+
+  get loader () {
+    if (this.props.queries.length) return null;
+    return <CircularProgress className={styles.loader} size={36} />;
   }
 
   get queries () {
@@ -149,6 +155,7 @@ export default class Queries extends Component {
             }}
           />
         </div>
+        { this.loader }
         <div className={styles.queries}>
           { this.cards }
         </div>

--- a/src/components/queries/queries.styles.scss
+++ b/src/components/queries/queries.styles.scss
@@ -38,3 +38,7 @@ $mobile-width: 600px;
 .link {
   text-decoration: none;
 }
+
+.loader {
+  margin: auto;
+}

--- a/src/components/queries/queries.test.js
+++ b/src/components/queries/queries.test.js
@@ -30,25 +30,43 @@ describe('Component: Queries', () => {
     expect(queries.exists()).toBe(true);
   });
 
-  it('calls loadQueries if the queries array has a length of 0', () => {
-    const component = shallow(<Queries {...props} />);
-    expect(props.loadQueries).toHaveBeenCalledTimes(1);
+  describe('queries haven\'t loaded yet', () => {
+    it('calls loadQueries', () => {
+      const component = shallow(<Queries {...props} />);
+      expect(props.loadQueries).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders loading graphic', () => {
+      const component = shallow(<Queries {...props} />);
+      const loader = component.find('.loader');
+      expect(loader.exists()).toBe(true);
+    });
   });
 
-  it('sorts queries alphabetically with favorites at the top', () => {
-    const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
-    const cards = component.find('CardHeader');
-    expect(cards.first().text()).toContain('Donuts!!!');
-    expect(cards.at(1).text()).toContain('Bars');
-    expect(cards.at(2).text()).toContain('Coffee shops');
-    expect(cards.at(3).text()).toContain('Thai food');
+  describe('queries are loaded', () => {
+    it('doesn\'t render a loading graphic', () => {
+      const component = shallow(<Queries {...props} queries={queries} />);
+      const loader = component.find('.loader');
+      expect(loader.exists()).toBe(false);
+    });
+
+    it('sorts them alphabetically with favorites at the top', () => {
+      const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
+      const cards = component.find('CardHeader');
+      expect(cards.first().text()).toContain('Donuts!!!');
+      expect(cards.at(1).text()).toContain('Bars');
+      expect(cards.at(2).text()).toContain('Coffee shops');
+      expect(cards.at(3).text()).toContain('Thai food');
+    });
   });
 
-  it('filters out queries that don\'t match the search value', () => {
-    const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
-    component.find('input').simulate('change', { target: { value: 'cof' } });
-    const cards = component.find('CardHeader');
-    expect(cards).toHaveLength(1);
-    expect(cards.text()).toContain('Coffee shops');
+  describe('search', () => {
+    it('filters out queries that don\'t match the search value', () => {
+      const component = mount(<BrowserRouter><Queries {...props} queries={queries} /></BrowserRouter>);
+      component.find('input').simulate('change', { target: { value: 'cof' } });
+      const cards = component.find('CardHeader');
+      expect(cards).toHaveLength(1);
+      expect(cards.text()).toContain('Coffee shops');
+    });
   });
 });

--- a/src/reducers/queries/queries.reducer.js
+++ b/src/reducers/queries/queries.reducer.js
@@ -1,28 +1,27 @@
 import uniqBy from 'lodash.uniqby';
+import storage from 'utils/storage';
 import {
   FAVORITE_QUERY,
   LOAD_QUERIES,
   UNFAVORITE_QUERY
 } from 'action-types';
 
-const { localStorage } = window; // eslint-disable-line
-
 export default function (state = [], { name, type, queries }) {
   switch (type) {
     case LOAD_QUERIES: {
-      const favorites = JSON.parse(localStorage.getItem('favorites')) || {};
+      const favorites = storage.get('favorites', {});
       return queries.map(query => ({ ...query, favorite: favorites[query.name] }));
     }
     case FAVORITE_QUERY: {
       const favoriteQuery = state.find(query => query.name === name);
-      const favorites = JSON.parse(localStorage.getItem('favorites')) || {};
-      localStorage.setItem('favorites', JSON.stringify({ ...favorites, [name]: true }));
+      const favorites = storage.get('favorites', {});
+      storage.set('favorites', { ...favorites, [name]: true });
       return uniqBy([{ ...favoriteQuery, favorite: true }, ...state], query => query.name);
     }
     case UNFAVORITE_QUERY: {
       const unfavoriteQuery = state.find(query => query.name === name);
-      const favorites = JSON.parse(localStorage.getItem('favorites')) || {};
-      localStorage.setItem('favorites', JSON.stringify({ ...favorites, [name]: false }));
+      const favorites = storage.get('favorites', {});
+      storage.set('favorites', { ...favorites, [name]: false });
       return uniqBy([{ ...unfavoriteQuery, favorite: false }, ...state], query => query.name);
     }
     default:

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,14 @@
+const { localStorage } = window; // eslint-disable-line
+
+const storage = {
+  get (key, defaultValue = '') {
+    const item = localStorage.getItem(key);
+    return item ? JSON.parse(item) : defaultValue;
+  },
+
+  set (key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};
+
+export default storage;


### PR DESCRIPTION
## First...
- [x] I added full test coverage for the introduced changes
- [ ] I added new node modules *If so, which packages and why?*
- [ ] I made changes to the build process *If so, why?*

## Problem
Closes #48 

The wait time for loading initial queries can take anywhere between 1 and 3 seconds. This means there's an awkward period of time in which nothing appears on the screen.

## Solution
1. Add a loading graphic during initial load
+
2. Cache queries in local storage and show cached results (if they exist) while loading a new set of queries from the server.

## Steps to test
🤷‍♂ 